### PR TITLE
Allow user to provide name for generic tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ post_extraction_commands = [
 hooks_directory = "<path>"
 
 [[generic]]
+# [optional]
+# The name of the tool.
+name = "<name>"
 # [optional], if 'download_urls' is configured
 # The URL to download the tool from.
 download_url = "<url>"

--- a/code/cli/src/test/resources/io/projectenv/core/cli/integration/project-env.toml
+++ b/code/cli/src/test/resources/io/projectenv/core/cli/integration/project-env.toml
@@ -26,6 +26,7 @@ version = "1.12.1.1550"
 hooks_directory = "hooks"
 
 [[generic]]
+name = "JAXB 3.0"
 download_url = "https://repo1.maven.org/maven2/com/sun/xml/bind/jaxb-ri/3.0.0/jaxb-ri-3.0.0.zip"
 environment_variables = { JAXB_HOME = "/" }
 path_elements = ["bin"]

--- a/code/tool-support/generic-tool-support/src/main/java/io/projectenv/core/toolsupport/nodejs/GenericToolConfiguration.java
+++ b/code/tool-support/generic-tool-support/src/main/java/io/projectenv/core/toolsupport/nodejs/GenericToolConfiguration.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 @Value.Immutable
 public interface GenericToolConfiguration {
 
+    Optional<String> getName();
+
     Optional<String> getPrimaryExecutable();
 
     Optional<String> getDownloadUrl();

--- a/code/tool-support/generic-tool-support/src/main/java/io/projectenv/core/toolsupport/nodejs/GenericToolSupport.java
+++ b/code/tool-support/generic-tool-support/src/main/java/io/projectenv/core/toolsupport/nodejs/GenericToolSupport.java
@@ -36,6 +36,11 @@ public class GenericToolSupport implements ToolSupport<GenericToolConfiguration>
         return createProjectEnvToolInfo(toolInstallationDetails);
     }
 
+    @Override
+    public String getDescription(GenericToolConfiguration toolConfiguration) {
+        return toolConfiguration.getName().orElse(ToolSupport.super.getDescription(toolConfiguration));
+    }
+
     private LocalToolInstallationDetails installTool(GenericToolConfiguration toolConfiguration, ToolSupportContext context) throws ToolSupportException {
         try {
             var steps = createInstallationSteps(toolConfiguration, context);


### PR DESCRIPTION
To provide a meaningful message to the CLI user, we should be able to provide a name for generic tools as well.