### PR TITLE
Start names and messages with upper case

### DIFF
--- a/code/cli/src/main/java/io/projectenv/core/cli/command/AbstractProjectEnvCliCommand.java
+++ b/code/cli/src/main/java/io/projectenv/core/cli/command/AbstractProjectEnvCliCommand.java
@@ -48,7 +48,7 @@ public abstract class AbstractProjectEnvCliCommand implements Callable<Integer> 
         } catch (Exception e) {
             var rootCauseMessage = ExceptionUtils.getRootCauseMessage(e);
 
-            ProcessOutput.writeInfoMessage("failed to " + spec.commandLine().getCommandName() + " tools: {0}", rootCauseMessage);
+            ProcessOutput.writeInfoMessage("Failed to " + spec.commandLine().getCommandName() + " tools: {0}", rootCauseMessage);
             ProcessOutput.writeDebugMessage(e);
 
             return CommandLine.ExitCode.SOFTWARE;
@@ -62,7 +62,7 @@ public abstract class AbstractProjectEnvCliCommand implements Callable<Integer> 
     private ToolSupportContext createToolSupportContext(ProjectEnvConfiguration configuration) throws IOException {
         var toolsDirectory = new File(projectRoot, configuration.getToolsDirectory());
         if (!toolsDirectory.getCanonicalPath().startsWith(projectRoot.getCanonicalPath())) {
-            throw new IllegalArgumentException("tools root must be located in project root");
+            throw new IllegalArgumentException("Tools root must be located in project root");
         }
 
         var localToolInstallationManager = new DefaultLocalToolInstallationManager(toolsDirectory);

--- a/code/cli/src/main/java/io/projectenv/core/cli/command/ProjectEnvInstallCommand.java
+++ b/code/cli/src/main/java/io/projectenv/core/cli/command/ProjectEnvInstallCommand.java
@@ -46,7 +46,7 @@ public class ProjectEnvInstallCommand extends AbstractProjectEnvCliCommand {
 
             return toolInstallationInfos;
         } catch (ToolSupportException e) {
-            throw new ProjectEnvException("failed to install tools", e);
+            throw new ProjectEnvException("Failed to install tools", e);
         }
     }
 
@@ -60,7 +60,7 @@ public class ProjectEnvInstallCommand extends AbstractProjectEnvCliCommand {
         var toolInfos = new ArrayList<ToolInfo>();
         for (var toolConfiguration : toolConfigurations) {
             if (toolSupport.isAvailable(toolConfiguration)) {
-                ProcessOutput.writeInfoMessage("installing {0}...", toolSupport.getDescription(toolConfiguration));
+                ProcessOutput.writeInfoMessage("Installing {0}...", toolSupport.getDescription(toolConfiguration));
                 toolInfos.add(toolSupport.prepareTool(toolConfiguration, toolSupportContext));
             } else {
                 ProcessOutput.writeInfoMessage("{0} is not available, skipping installation", toolSupport.getToolIdentifier());
@@ -91,7 +91,7 @@ public class ProjectEnvInstallCommand extends AbstractProjectEnvCliCommand {
         FileUtils.write(target, content, StandardCharsets.UTF_8);
 
         if (!SystemUtils.IS_OS_WINDOWS && !target.setExecutable(true)) {
-            ProcessOutput.writeInfoMessage("failed to make file {0} executable", target.getCanonicalPath());
+            ProcessOutput.writeInfoMessage("Failed to make file {0} executable", target.getCanonicalPath());
         }
     }
 

--- a/code/cli/src/main/java/io/projectenv/core/cli/command/ProjectEnvUpgradeCommand.java
+++ b/code/cli/src/main/java/io/projectenv/core/cli/command/ProjectEnvUpgradeCommand.java
@@ -50,7 +50,7 @@ public class ProjectEnvUpgradeCommand extends AbstractProjectEnvCliCommand {
 
             return toolUpgradeInfos;
         } catch (ToolSupportException e) {
-            throw new ProjectEnvException("failed to upgrade tools", e);
+            throw new ProjectEnvException("Failed to upgrade tools", e);
         }
     }
 
@@ -96,7 +96,7 @@ public class ProjectEnvUpgradeCommand extends AbstractProjectEnvCliCommand {
     }
 
     private String applyToolUpgrade(String rawProjectEnvConfiguration, String toolIdentifier, ToolUpgradeInfo toolUpgradeInfo) {
-        ProcessOutput.writeInfoMessage("upgrading {0} from {1} to {2}...", toolIdentifier, toolUpgradeInfo.getCurrentVersion(), toolUpgradeInfo.getUpgradedVersion());
+        ProcessOutput.writeInfoMessage("Upgrading {0} from {1} to {2}...", toolIdentifier, toolUpgradeInfo.getCurrentVersion(), toolUpgradeInfo.getUpgradedVersion());
 
         String currentVersion = Pattern.quote(toolUpgradeInfo.getCurrentVersion());
         return rawProjectEnvConfiguration

--- a/code/cli/src/main/java/io/projectenv/core/cli/index/DefaultToolsIndexManager.java
+++ b/code/cli/src/main/java/io/projectenv/core/cli/index/DefaultToolsIndexManager.java
@@ -52,14 +52,14 @@ public class DefaultToolsIndexManager implements ToolsIndexManager {
             downloadToolsIndex(toolsIndexFile);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new ProjectEnvException("interrupted while downloading tools index", e);
+            throw new ProjectEnvException("Interrupted while downloading tools index", e);
         } catch (Exception e) {
-            ProcessOutput.writeDebugMessage("failed to update tools index: {0}", e.getMessage());
+            ProcessOutput.writeDebugMessage("Failed to update tools index: {0}", e.getMessage());
             ProcessOutput.writeDebugMessage(e);
         }
 
         if (!toolsIndexFile.exists()) {
-            throw new ProjectEnvException("could not load tools index as the download failed and no local copy is present");
+            throw new ProjectEnvException("Could not load tools index as the download failed and no local copy is present");
         }
 
         try (Reader reader = new FileReader(toolsIndexFile, StandardCharsets.UTF_8)) {
@@ -109,7 +109,7 @@ public class DefaultToolsIndexManager implements ToolsIndexManager {
     @Override
     public String resolveMavenDistributionUrl(String version) {
         return Optional.ofNullable(getToolsIndex().getMavenVersions().get(ToolVersionHelper.getVersionWithoutPrefix(version)))
-                .orElseThrow(() -> new ToolsIndexException("failed to resolve Maven " + version + " from tool index"));
+                .orElseThrow(() -> new ToolsIndexException("Failed to resolve Maven " + version + " from tool index"));
     }
 
     @Override
@@ -120,7 +120,7 @@ public class DefaultToolsIndexManager implements ToolsIndexManager {
     @Override
     public String resolveGradleDistributionUrl(String version) {
         return Optional.ofNullable(getToolsIndex().getGradleVersions().get(ToolVersionHelper.getVersionWithoutPrefix(version)))
-                .orElseThrow(() -> new ToolsIndexException("failed to resolve Gradle " + version + " from tool index"));
+                .orElseThrow(() -> new ToolsIndexException("Failed to resolve Gradle " + version + " from tool index"));
     }
 
     @Override
@@ -133,7 +133,7 @@ public class DefaultToolsIndexManager implements ToolsIndexManager {
         return Optional.ofNullable(getToolsIndex().getNodeVersions().get(ToolVersionHelper.getVersionWithoutPrefix(version)))
                 .map(versionEntry -> versionEntry.get(OperatingSystem.getCurrentOperatingSystem()))
                 .map(this::resolveDownloadUrlForCpuArchitecture)
-                .orElseThrow(() -> new ToolsIndexException("failed to resolve NodeJS " + version + " from tool index"));
+                .orElseThrow(() -> new ToolsIndexException("Failed to resolve NodeJS " + version + " from tool index"));
     }
 
     @Override
@@ -148,7 +148,7 @@ public class DefaultToolsIndexManager implements ToolsIndexManager {
                 .map(jdkDistributionEntry -> jdkDistributionEntry.get(ToolVersionHelper.getVersionWithoutPrefix(version)))
                 .map(versionEntry -> versionEntry.get(OperatingSystem.getCurrentOperatingSystem()))
                 .map(this::resolveDownloadUrlForCpuArchitecture)
-                .orElseThrow(() -> new ToolsIndexException("failed to resolve " + jdkDistribution + " " + version + " from tool index"));
+                .orElseThrow(() -> new ToolsIndexException("Failed to resolve " + jdkDistribution + " " + version + " from tool index"));
     }
 
     @Override
@@ -163,7 +163,7 @@ public class DefaultToolsIndexManager implements ToolsIndexManager {
     public String resolveClojureDistributionUrl(String version) {
         return Optional.ofNullable(getToolsIndex().getClojureVersions().get(ToolVersionHelper.getVersionWithoutPrefix(version)))
                 .map(versionEntry -> versionEntry.get(OperatingSystem.getCurrentOperatingSystem()))
-                .orElseThrow(() -> new ToolsIndexException("failed to resolve Clojure " + version + " from tool index"));
+                .orElseThrow(() -> new ToolsIndexException("Failed to resolve Clojure " + version + " from tool index"));
     }
 
     @Override
@@ -207,7 +207,7 @@ public class DefaultToolsIndexManager implements ToolsIndexManager {
 
             return toolsIndexV2;
         } catch (IOException e) {
-            throw new ProjectEnvException("failed to load tool index", e);
+            throw new ProjectEnvException("Failed to load tool index", e);
         }
     }
 

--- a/code/cli/src/main/java/io/projectenv/core/cli/installer/DefaultLocalToolInstallationManager.java
+++ b/code/cli/src/main/java/io/projectenv/core/cli/installer/DefaultLocalToolInstallationManager.java
@@ -42,7 +42,7 @@ public class DefaultLocalToolInstallationManager implements LocalToolInstallatio
         } catch (Exception e) {
             cleanUpFailedToolInstallation(toolInstallationRoot);
 
-            throw new LocalToolInstallationManagerException("failed to install tool " + toolName, e);
+            throw new LocalToolInstallationManagerException("Failed to install tool " + toolName, e);
         }
     }
 
@@ -50,7 +50,7 @@ public class DefaultLocalToolInstallationManager implements LocalToolInstallatio
         try {
             FileUtils.forceDelete(toolInstallationRoot);
         } catch (IOException e) {
-            ProcessOutput.writeInfoMessage("failed to delete tool installation directory {0}: {1}", toolInstallationRoot.getAbsolutePath(), e.getMessage());
+            ProcessOutput.writeInfoMessage("Failed to delete tool installation directory {0}: {1}", toolInstallationRoot.getAbsolutePath(), e.getMessage());
         }
     }
 

--- a/code/cli/src/main/java/io/projectenv/core/cli/installer/lock/LockFileHelper.java
+++ b/code/cli/src/main/java/io/projectenv/core/cli/installer/lock/LockFileHelper.java
@@ -19,7 +19,7 @@ public final class LockFileHelper {
         while (lockFile.exists()) {
             long passedMillis = System.currentTimeMillis() - waitingSinceMillis;
             if (timout.minus(passedMillis, ChronoUnit.MILLIS).isNegative()) {
-                throw new TimeoutException("timeout while trying to acquire lock file " + lockFile.getCanonicalPath());
+                throw new TimeoutException("Timeout while trying to acquire lock file " + lockFile.getCanonicalPath());
             }
 
             try {
@@ -27,13 +27,13 @@ public final class LockFileHelper {
             } catch (InterruptedException e) {
                 // re-set interrupt flag on thread
                 Thread.currentThread().interrupt();
-                throw new IOException("tried to acquire lock files, but was interrupted", e);
+                throw new IOException("Tried to acquire lock files, but was interrupted", e);
             }
         }
 
         FileUtils.forceMkdirParent(lockFile);
         if (!lockFile.createNewFile()) {
-            throw new IOException("failed to create lock file " + lockFile.getCanonicalPath());
+            throw new IOException("Failed to create lock file " + lockFile.getCanonicalPath());
         }
 
         return new LockFile(lockFile);

--- a/code/cli/src/main/java/io/projectenv/core/cli/nativeimage/ProjectEnvFeature.java
+++ b/code/cli/src/main/java/io/projectenv/core/cli/nativeimage/ProjectEnvFeature.java
@@ -70,7 +70,7 @@ public class ProjectEnvFeature implements Feature {
             registerTemplate("cygwin.peb");
             registerTemplate("pwsh.peb");
         } catch (IOException e) {
-            throw new IllegalStateException("failed to register templates for usage in native-image");
+            throw new IllegalStateException("Failed to register templates for usage in native-image");
         }
     }
 

--- a/code/cli/src/test/java/io/projectenv/core/cli/installer/DefaultLocalToolInstallationManagerTest.java
+++ b/code/cli/src/test/java/io/projectenv/core/cli/installer/DefaultLocalToolInstallationManagerTest.java
@@ -23,7 +23,7 @@ class DefaultLocalToolInstallationManagerTest {
 
         assertThatExceptionOfType(LocalToolInstallationManagerException.class)
                 .isThrownBy(() -> localToolInstallationManager.installOrUpdateTool("test", List.of(new ExceptionThrowingLocalToolInstallationStep("test"))))
-                .withMessage("failed to install tool test");
+                .withMessage("Failed to install tool test");
 
         assertThat(tempDir).isEmptyDirectory();
     }
@@ -38,12 +38,12 @@ class DefaultLocalToolInstallationManagerTest {
 
         @Override
         public LocalToolInstallationDetails executeInstallStep(File installationRoot, LocalToolInstallationDetails intermediateInstallationDetails) throws LocalToolInstallationStepException {
-            throw new LocalToolInstallationStepException("something went wrong");
+            throw new LocalToolInstallationStepException("Something went wrong");
         }
 
         @Override
         public LocalToolInstallationDetails executeUpdateStep(File installationRoot, LocalToolInstallationDetails intermediateInstallationDetails) throws LocalToolInstallationStepException {
-            throw new LocalToolInstallationStepException("something went wrong");
+            throw new LocalToolInstallationStepException("Something went wrong");
         }
 
         @Override

--- a/code/commons/archive/src/main/java/io/projectenv/core/commons/archive/impl/DefaultArchiveExtractor.java
+++ b/code/commons/archive/src/main/java/io/projectenv/core/commons/archive/impl/DefaultArchiveExtractor.java
@@ -56,7 +56,7 @@ public class DefaultArchiveExtractor implements ArchiveExtractor {
 
     private void checkThatPathIsInsideBasePath(File file, File baseDirectory) throws IOException {
         if (!file.getCanonicalPath().startsWith(baseDirectory.getCanonicalPath())) {
-            throw new IllegalStateException("path " + file.getPath() + " is pointing to a location outside " + baseDirectory.getCanonicalPath());
+            throw new IllegalStateException("Path " + file.getPath() + " is pointing to a location outside " + baseDirectory.getCanonicalPath());
         }
     }
 

--- a/code/commons/archive/src/main/java/io/projectenv/core/commons/archive/impl/accessor/ArchiveAccessorFactory.java
+++ b/code/commons/archive/src/main/java/io/projectenv/core/commons/archive/impl/accessor/ArchiveAccessorFactory.java
@@ -33,7 +33,7 @@ public class ArchiveAccessorFactory {
             }
         }
 
-        throw new IllegalArgumentException("unsupported archive " + archive.getName());
+        throw new IllegalArgumentException("Unsupported archive " + archive.getName());
     }
 
     private static ArchiveAccessor createZipArchiveAccessor(File archive) throws IOException {

--- a/code/commons/native-image/src/main/java/io/projectenv/core/commons/nativeimage/NativeImageHelper.java
+++ b/code/commons/native-image/src/main/java/io/projectenv/core/commons/nativeimage/NativeImageHelper.java
@@ -23,7 +23,7 @@ public final class NativeImageHelper {
     }
 
     public static void registerResource(String resource) {
-        ProcessOutput.writeInfoMessage("registering resource {0} in native image", resource);
+        ProcessOutput.writeInfoMessage("Registering resource {0} in native image", resource);
         RuntimeResourceAccess.addResource(NativeImageHelper.class.getModule(), resource);
     }
 
@@ -45,20 +45,20 @@ public final class NativeImageHelper {
     }
 
     public static void registerFieldsWithAnnotationForReflection(String basePackage, Class<? extends Annotation> annotationClazz) {
-        ProcessOutput.writeInfoMessage("scanning package {0} for fields with annotation {1}", basePackage, annotationClazz.getSimpleName());
+        ProcessOutput.writeInfoMessage("Scanning package {0} for fields with annotation {1}", basePackage, annotationClazz.getSimpleName());
 
         Reflections reflections = new Reflections(new ConfigurationBuilder()
                 .forPackages(basePackage)
                 .setScanners(Scanners.FieldsAnnotated));
 
         for (Field field : reflections.getFieldsAnnotatedWith(annotationClazz)) {
-            ProcessOutput.writeInfoMessage("registering field {0} for reflection in native image", field.getName());
+            ProcessOutput.writeInfoMessage("Registering field {0} for reflection in native image", field.getName());
             RuntimeReflection.register(field);
         }
     }
 
     public static void registerClassForReflection(Class<?> clazz) {
-        ProcessOutput.writeInfoMessage("registering class {0} for reflection in native image", clazz.getName());
+        ProcessOutput.writeInfoMessage("Registering class {0} for reflection in native image", clazz.getName());
         RuntimeReflection.register(clazz);
         RuntimeReflection.register(clazz.getDeclaredMethods());
         RuntimeReflection.register(clazz.getDeclaredFields());

--- a/code/commons/process/src/main/java/io/projectenv/core/commons/process/ProcessEnvironmentHelper.java
+++ b/code/commons/process/src/main/java/io/projectenv/core/commons/process/ProcessEnvironmentHelper.java
@@ -97,7 +97,7 @@ public final class ProcessEnvironmentHelper {
             }
         }
 
-        throw new IllegalStateException("could not resolve path variable name");
+        throw new IllegalStateException("Could not resolve path variable name");
     }
 
 }

--- a/code/commons/process/src/main/java/io/projectenv/core/commons/process/ProcessHelper.java
+++ b/code/commons/process/src/main/java/io/projectenv/core/commons/process/ProcessHelper.java
@@ -55,7 +55,7 @@ public final class ProcessHelper {
                     .build();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new IOException("interrupted while waiting for process termination");
+            throw new IOException("Interrupted while waiting for process termination");
         }
     }
 

--- a/code/tool-support/clojure-support/src/main/java/io/projectenv/core/toolsupport/clojure/ClojureSupport.java
+++ b/code/tool-support/clojure-support/src/main/java/io/projectenv/core/toolsupport/clojure/ClojureSupport.java
@@ -25,6 +25,11 @@ public class ClojureSupport extends AbstractUpgradableToolSupport<ClojureConfigu
     }
 
     @Override
+    public String getName(ClojureConfiguration toolConfiguration) {
+        return "Clojure";
+    }
+
+    @Override
     public Class<ClojureConfiguration> getToolConfigurationClass() {
         return ClojureConfiguration.class;
     }
@@ -52,7 +57,7 @@ public class ClojureSupport extends AbstractUpgradableToolSupport<ClojureConfigu
 
             return context.getLocalToolInstallationManager().installOrUpdateTool(getToolIdentifier(), steps);
         } catch (LocalToolInstallationManagerException e) {
-            throw new ToolSupportException("failed to install tool", e);
+            throw new ToolSupportException("Failed to install tool", e);
         }
     }
 

--- a/code/tool-support/generic-tool-support/src/main/java/io/projectenv/core/toolsupport/nodejs/GenericToolSupport.java
+++ b/code/tool-support/generic-tool-support/src/main/java/io/projectenv/core/toolsupport/nodejs/GenericToolSupport.java
@@ -42,7 +42,7 @@ public class GenericToolSupport implements ToolSupport<GenericToolConfiguration>
 
             return context.getLocalToolInstallationManager().installOrUpdateTool(getToolIdentifier(), steps);
         } catch (LocalToolInstallationManagerException e) {
-            throw new ToolSupportException("failed to install tool", e);
+            throw new ToolSupportException("Failed to install tool", e);
         }
     }
 

--- a/code/tool-support/git-support/src/main/java/io/projectenv/core/toolsupport/git/GitSupport.java
+++ b/code/tool-support/git-support/src/main/java/io/projectenv/core/toolsupport/git/GitSupport.java
@@ -20,6 +20,11 @@ public class GitSupport implements ToolSupport<GitConfiguration> {
     }
 
     @Override
+    public String getDescription(GitConfiguration toolConfiguration) {
+        return "Git hooks";
+    }
+
+    @Override
     public Class<GitConfiguration> getToolConfigurationClass() {
         return GitConfiguration.class;
     }
@@ -39,7 +44,7 @@ public class GitSupport implements ToolSupport<GitConfiguration> {
                     .handledProjectResources(gitHooks)
                     .build();
         } catch (IOException e) {
-            throw new ToolSupportException("failed to copy Git hooks", e);
+            throw new ToolSupportException("Failed to copy Git hooks", e);
         }
     }
 

--- a/code/tool-support/gradle-support/src/main/java/io/projectenv/core/toolsupport/gradle/GradleSupport.java
+++ b/code/tool-support/gradle-support/src/main/java/io/projectenv/core/toolsupport/gradle/GradleSupport.java
@@ -23,6 +23,11 @@ public class GradleSupport extends AbstractUpgradableToolSupport<GradleConfigura
     }
 
     @Override
+    public String getName(GradleConfiguration toolConfiguration) {
+        return "Gradle";
+    }
+
+    @Override
     public Class<GradleConfiguration> getToolConfigurationClass() {
         return GradleConfiguration.class;
     }
@@ -50,7 +55,7 @@ public class GradleSupport extends AbstractUpgradableToolSupport<GradleConfigura
 
             return context.getLocalToolInstallationManager().installOrUpdateTool(getToolIdentifier(), steps);
         } catch (LocalToolInstallationManagerException e) {
-            throw new ToolSupportException("failed to install tool", e);
+            throw new ToolSupportException("Failed to install tool", e);
         }
     }
 

--- a/code/tool-support/jdk-support/src/main/java/io/projectenv/core/toolsupport/jdk/JdkSupport.java
+++ b/code/tool-support/jdk-support/src/main/java/io/projectenv/core/toolsupport/jdk/JdkSupport.java
@@ -24,6 +24,11 @@ public class JdkSupport extends AbstractUpgradableToolSupport<JdkConfiguration> 
     }
 
     @Override
+    public String getName(JdkConfiguration toolConfiguration) {
+        return "Java (" + toolConfiguration.getDistribution() + ")";
+    }
+
+    @Override
     public Class<JdkConfiguration> getToolConfigurationClass() {
         return JdkConfiguration.class;
     }
@@ -51,7 +56,7 @@ public class JdkSupport extends AbstractUpgradableToolSupport<JdkConfiguration> 
 
             return context.getLocalToolInstallationManager().installOrUpdateTool(getToolIdentifier(), steps);
         } catch (LocalToolInstallationManagerException e) {
-            throw new ToolSupportException("failed to install tool", e);
+            throw new ToolSupportException("Failed to install tool", e);
         }
     }
 

--- a/code/tool-support/maven-support/src/main/java/io/projectenv/core/toolsupport/maven/MavenSupport.java
+++ b/code/tool-support/maven-support/src/main/java/io/projectenv/core/toolsupport/maven/MavenSupport.java
@@ -24,6 +24,11 @@ public class MavenSupport extends AbstractUpgradableToolSupport<MavenConfigurati
     }
 
     @Override
+    public String getName(MavenConfiguration toolConfiguration) {
+        return "Maven";
+    }
+
+    @Override
     public Class<MavenConfiguration> getToolConfigurationClass() {
         return MavenConfiguration.class;
     }
@@ -70,7 +75,7 @@ public class MavenSupport extends AbstractUpgradableToolSupport<MavenConfigurati
 
             return context.getLocalToolInstallationManager().installOrUpdateTool(getToolIdentifier(), steps);
         } catch (LocalToolInstallationManagerException e) {
-            throw new ToolSupportException("failed to install tool", e);
+            throw new ToolSupportException("Failed to install tool", e);
         }
     }
 

--- a/code/tool-support/nodejs-support/src/main/java/io/projectenv/core/toolsupport/nodejs/NodeJsSupport.java
+++ b/code/tool-support/nodejs-support/src/main/java/io/projectenv/core/toolsupport/nodejs/NodeJsSupport.java
@@ -24,6 +24,11 @@ public class NodeJsSupport extends AbstractUpgradableToolSupport<NodeJsConfigura
     }
 
     @Override
+    public String getName(NodeJsConfiguration toolConfiguration) {
+        return "NodeJS";
+    }
+
+    @Override
     public Class<NodeJsConfiguration> getToolConfigurationClass() {
         return NodeJsConfiguration.class;
     }
@@ -51,7 +56,7 @@ public class NodeJsSupport extends AbstractUpgradableToolSupport<NodeJsConfigura
 
             return context.getLocalToolInstallationManager().installOrUpdateTool(getToolIdentifier(), steps);
         } catch (LocalToolInstallationManagerException e) {
-            throw new ToolSupportException("failed to install tool", e);
+            throw new ToolSupportException("Failed to install tool", e);
         }
     }
 

--- a/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/AbstractUpgradableToolSupport.java
+++ b/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/AbstractUpgradableToolSupport.java
@@ -33,8 +33,12 @@ public abstract class AbstractUpgradableToolSupport<T> implements ToolSupport<T>
 
     protected abstract Set<String> getAllValidVersions(T toolConfiguration, ToolSupportContext context);
 
+    public String getName(T toolConfiguration) {
+        return getToolIdentifier();
+    }
+
     @Override
     public String getDescription(T toolConfiguration) {
-		return getToolIdentifier() + " " + ToolVersionHelper.getVersionWithoutPrefix(getCurrentVersion(toolConfiguration));
+		return getName(toolConfiguration) + " " + ToolVersionHelper.getVersionWithoutPrefix(getCurrentVersion(toolConfiguration));
     }
 }

--- a/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/DeleteFileStep.java
+++ b/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/DeleteFileStep.java
@@ -30,7 +30,7 @@ public class DeleteFileStep implements LocalToolInstallationStep {
 
             return intermediateInstallationDetails;
         } catch (IOException e) {
-            throw new LocalToolInstallationStepException("failed to execute step", e);
+            throw new LocalToolInstallationStepException("Failed to execute step", e);
         }
     }
 

--- a/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/ExecuteCommandStep.java
+++ b/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/ExecuteCommandStep.java
@@ -35,7 +35,7 @@ public class ExecuteCommandStep implements LocalToolInstallationStep {
 
             var rawPostInstallationCommandParts = List.of(StringUtils.split(rawCommand));
             if (rawPostInstallationCommandParts.isEmpty()) {
-                throw new LocalToolInstallationStepException("empty command");
+                throw new LocalToolInstallationStepException("Empty command");
             }
 
             var executable = getExecutableNameFromRawCommand(rawPostInstallationCommandParts);
@@ -52,7 +52,7 @@ public class ExecuteCommandStep implements LocalToolInstallationStep {
 
             return intermediateInstallationDetails;
         } catch (IOException e) {
-            throw new LocalToolInstallationStepException("failed to execute step", e);
+            throw new LocalToolInstallationStepException("Failed to execute step", e);
         }
     }
     @Override

--- a/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/ExtractArchiveStep.java
+++ b/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/ExtractArchiveStep.java
@@ -59,18 +59,18 @@ public class ExtractArchiveStep implements LocalToolInstallationStep {
     private Path downloadArchive() throws LocalToolInstallationStepException {
         Path archiveCachePath = getArchiveCachePath();
         if (Files.exists(archiveCachePath)) {
-            ProcessOutput.writeDebugMessage("using cached archive from {0}", archiveCachePath);
+            ProcessOutput.writeDebugMessage("Using cached archive from {0}", archiveCachePath);
             return archiveCachePath;
         }
 
         Path archiveDownloadingPath = getArchiveDownloadingPath();
         if (Files.exists(archiveDownloadingPath)) {
             waitUntilArchiveHasBeenDownloadedByOtherProcess(archiveCachePath);
-            ProcessOutput.writeDebugMessage("using cached archive from {0}", archiveCachePath);
+            ProcessOutput.writeDebugMessage("Using cached archive from {0}", archiveCachePath);
             return archiveCachePath;
         }
 
-        ProcessOutput.writeDebugMessage("downloading archive from {0}", rawArchiveUri);
+        ProcessOutput.writeDebugMessage("Downloading archive from {0}", rawArchiveUri);
 
         try {
             HttpResponse<InputStream> response = httpClientProvider.getHttpClient().send(
@@ -90,16 +90,16 @@ public class ExtractArchiveStep implements LocalToolInstallationStep {
                 Thread.currentThread().interrupt();
             }
             deleteIfExists(archiveDownloadingPath);
-            throw new LocalToolInstallationStepException("failed to download archive from URI " + rawArchiveUri, e);
+            throw new LocalToolInstallationStepException("Failed to download archive from URI " + rawArchiveUri, e);
         }
 
         try {
             Files.move(archiveDownloadingPath, archiveCachePath);
-            ProcessOutput.writeDebugMessage("cached archive at {0}", archiveCachePath);
+            ProcessOutput.writeDebugMessage("Cached archive at {0}", archiveCachePath);
         } catch (IOException e) {
             deleteIfExists(archiveDownloadingPath);
             deleteIfExists(archiveCachePath);
-            throw new LocalToolInstallationStepException("failed to move downloaded archive from " + archiveDownloadingPath + " to " + archiveCachePath, e);
+            throw new LocalToolInstallationStepException("Failed to move downloaded archive from " + archiveDownloadingPath + " to " + archiveCachePath, e);
         }
 
         return archiveCachePath;
@@ -109,7 +109,7 @@ public class ExtractArchiveStep implements LocalToolInstallationStep {
         try {
             return getCacheDirectory().resolve(FilenameUtils.getName(rawArchiveUri));
         } catch (IOException e) {
-            throw new LocalToolInstallationStepException("failed to resolve archive cache path for URI " + rawArchiveUri, e);
+            throw new LocalToolInstallationStepException("Failed to resolve archive cache path for URI " + rawArchiveUri, e);
         }
     }
 
@@ -137,7 +137,7 @@ public class ExtractArchiveStep implements LocalToolInstallationStep {
         }
 
         if (!Files.exists(archivePath)) {
-            throw new LocalToolInstallationStepException("failed to wait for archive to be downloaded");
+            throw new LocalToolInstallationStepException("Failed to wait for archive to be downloaded");
         }
     }
 
@@ -163,7 +163,7 @@ public class ExtractArchiveStep implements LocalToolInstallationStep {
             ArchiveExtractorFactory.createArchiveExtractor().extractArchive(localArchivePath.toFile(), installationRoot);
         } catch (IOException e) {
             deleteIfExists(localArchivePath);
-            throw new LocalToolInstallationStepException("failed to extract archive from URI " + rawArchiveUri, e);
+            throw new LocalToolInstallationStepException("Failed to extract archive from URI " + rawArchiveUri, e);
         }
     }
 

--- a/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/MoveFileStep.java
+++ b/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/MoveFileStep.java
@@ -34,7 +34,7 @@ public class MoveFileStep implements LocalToolInstallationStep {
 
             return intermediateInstallationDetails;
         } catch (IOException e) {
-            throw new LocalToolInstallationStepException("failed to execute step", e);
+            throw new LocalToolInstallationStepException("Failed to execute step", e);
         }
     }
 

--- a/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/OverwriteFileStep.java
+++ b/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/OverwriteFileStep.java
@@ -41,7 +41,7 @@ public class OverwriteFileStep implements LocalToolInstallationStep {
                     .addFileOverwrites(Pair.of(source, target))
                     .build();
         } catch (IOException e) {
-            throw new LocalToolInstallationStepException("failed to execute step", e);
+            throw new LocalToolInstallationStepException("Failed to execute step", e);
         }
     }
 

--- a/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/ReplaceInFileStep.java
+++ b/code/tool-support/tool-support-commons/src/main/java/io/projectenv/core/toolsupport/commons/commands/ReplaceInFileStep.java
@@ -42,7 +42,7 @@ public class ReplaceInFileStep implements LocalToolInstallationStep {
 
             return intermediateInstallationDetails;
         } catch (IOException e) {
-            throw new LocalToolInstallationStepException("failed to execute step", e);
+            throw new LocalToolInstallationStepException("Failed to execute step", e);
         }
     }
 


### PR DESCRIPTION
This pull request is opinionated. Feel free to reject it in case you have a different opinion.

I'm used to read names ("Maven", "Gradle") and sentences ("Failed to download Maven") starting with a capital letter. I think most CLI tools do it that way as well. This change also allows writing "NodeJS" and "JDK" in correct casing.

Let me know what you think. Thanks!