### PR TITLE
Make the sh template Windows compatible and call Maven through a function

### DIFF
--- a/code/cli/src/main/java/io/projectenv/core/cli/shell/TemplateProcessor.java
+++ b/code/cli/src/main/java/io/projectenv/core/cli/shell/TemplateProcessor.java
@@ -5,6 +5,7 @@ import io.pebbletemplates.pebble.extension.AbstractExtension;
 import io.pebbletemplates.pebble.extension.Filter;
 import io.pebbletemplates.pebble.template.EvaluationContext;
 import io.pebbletemplates.pebble.template.PebbleTemplate;
+import io.projectenv.core.commons.system.OperatingSystem;
 import io.projectenv.core.toolsupport.spi.ToolInfo;
 import org.apache.commons.lang3.ClassPathUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -34,12 +35,28 @@ public final class TemplateProcessor {
     }
 
     public static String processTemplate(String template, Map<String, List<ToolInfo>> toolInfos) throws IOException {
+        return processTemplate(template, toolInfos, OperatingSystem.getCurrentOperatingSystem() == OperatingSystem.WINDOWS);
+    }
+
+    /**
+     * Renders a template with an explicit target operating system.
+     * <p>
+     * Only the OS decides whether a POSIX shell needs its paths converted: on Windows
+     * a POSIX shell is Cygwin or MSYS2, where {@code :} separates PATH entries, so a
+     * path such as {@code C:/x/bin} would split in two. The conversion is left to
+     * {@code cygpath} at runtime rather than done here, because the two environments
+     * disagree on the result ({@code /cygdrive/c/x/bin} vs {@code /c/x/bin}).
+     *
+     * @param windows whether the rendered script will run on Windows
+     */
+    static String processTemplate(String template, Map<String, List<ToolInfo>> toolInfos, boolean windows) throws IOException {
         PebbleTemplate compiledTemplate = PEBBLE_ENGINE.getTemplate(resolveTemplate(template));
 
         Writer writer = new StringWriter();
 
         var context = new HashMap<String, Object>();
         context.put("toolInfos", toolInfos);
+        context.put("windows", windows);
 
         compiledTemplate.evaluate(writer, context);
 

--- a/code/cli/src/main/resources/io/projectenv/core/cli/shell/cygwin.peb
+++ b/code/cli/src/main/resources/io/projectenv/core/cli/shell/cygwin.peb
@@ -12,7 +12,9 @@ export PATH="$(cygpath '{{ pathElement | path }}'):$PATH"
 
 {% if entry.key == "maven" %}
 {% if toolInfo.unhandledProjectResources.userSettingsFile != null %}
-alias mvn="mvn -s {{ toolInfo.unhandledProjectResources.userSettingsFile | path }}"
+mvn() {
+    command mvn -s "{{ toolInfo.unhandledProjectResources.userSettingsFile | path }}" "$@"
+}
 {% endif %}
 {% endif %}
 

--- a/code/cli/src/main/resources/io/projectenv/core/cli/shell/sh.peb
+++ b/code/cli/src/main/resources/io/projectenv/core/cli/shell/sh.peb
@@ -3,16 +3,26 @@
 {% for toolInfo in entry.value %}
 
 {% for environmentVariable in toolInfo.environmentVariables %}
+{% if windows %}
+export {{ environmentVariable.key }}="$(cygpath '{{ environmentVariable.value | path }}')"
+{% else %}
 export {{ environmentVariable.key }}="{{ environmentVariable.value | path }}"
+{% endif %}
 {% endfor %}
 
 {% for pathElement in toolInfo.pathElements %}
+{% if windows %}
+export PATH="$(cygpath '{{ pathElement | path }}'):$PATH"
+{% else %}
 export PATH="{{ pathElement | path }}:$PATH"
+{% endif %}
 {% endfor %}
 
 {% if entry.key == "maven" %}
 {% if toolInfo.unhandledProjectResources.userSettingsFile != null %}
-alias mvn="mvn -s {{ toolInfo.unhandledProjectResources.userSettingsFile | path }}"
+mvn() {
+    command mvn -s "{{ toolInfo.unhandledProjectResources.userSettingsFile | path }}" "$@"
+}
 {% endif %}
 {% endif %}
 

--- a/code/cli/src/test/java/io/projectenv/core/cli/integration/AbstractProjectEnvCliTest.java
+++ b/code/cli/src/test/java/io/projectenv/core/cli/integration/AbstractProjectEnvCliTest.java
@@ -111,7 +111,7 @@ abstract class AbstractProjectEnvCliTest {
                 .contains("export MAVEN_HOME")
                 .contains("export JAVA_HOME")
                 .contains("export JAXB_HOME")
-                .contains("alias mvn")
+                .contains("mvn() {")
                 .contains("export PATH");
     }
 

--- a/code/cli/src/test/java/io/projectenv/core/cli/shell/TemplateProcessorTest.java
+++ b/code/cli/src/test/java/io/projectenv/core/cli/shell/TemplateProcessorTest.java
@@ -1,5 +1,7 @@
 package io.projectenv.core.cli.shell;
 
+import io.projectenv.core.toolsupport.spi.ImmutableToolInfo;
+import io.projectenv.core.toolsupport.spi.ToolInfo;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
@@ -7,6 +9,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +48,63 @@ class TemplateProcessorTest {
 
         var actualContent = TemplateProcessor.processTemplate(customTemplate, Map.of());
         assertThat(actualContent).isEqualTo(expectedContent);
+    }
+
+    @Test
+    void testShTemplateExposesMavenSettingsAsFunction() throws Exception {
+        var actualContent = TemplateProcessor.processTemplate("sh", mavenToolInfos(), false);
+
+        // A function, not an alias: an alias is silently ignored by any non-interactive
+        // shell, so the settings file would be dropped in CI and in `sh -c`.
+        assertThat(actualContent).contains("mvn() {");
+        assertThat(actualContent).contains("command mvn -s \"/project/etc/m2/settings.xml\" \"$@\"");
+        assertThat(actualContent).doesNotContain("alias mvn");
+    }
+
+    @Test
+    void testShTemplateLeavesPathsUntouchedOffWindows() throws Exception {
+        var actualContent = TemplateProcessor.processTemplate("sh", mavenToolInfos(), false);
+
+        assertThat(actualContent).contains("export MAVEN_HOME=\"/tools/maven\"");
+        assertThat(actualContent).contains("export PATH=\"/tools/maven/bin:$PATH\"");
+        assertThat(actualContent).doesNotContain("cygpath");
+    }
+
+    @Test
+    void testShTemplateConvertsPathsOnWindows() throws Exception {
+        var actualContent = TemplateProcessor.processTemplate("sh", mavenToolInfos(), true);
+
+        // A POSIX shell on Windows is Cygwin or MSYS2, where ':' separates PATH entries.
+        // Without the conversion, 'C:/tools/maven/bin' would split into 'C' and
+        // '/tools/maven/bin', leaving a dead entry.
+        assertThat(actualContent).contains("export MAVEN_HOME=\"$(cygpath '/tools/maven')\"");
+        assertThat(actualContent).contains("export PATH=\"$(cygpath '/tools/maven/bin'):$PATH\"");
+    }
+
+    @Test
+    void testCygwinTemplateMatchesTheWindowsRenderingOfSh() throws Exception {
+        var shOnWindows = TemplateProcessor.processTemplate("sh", mavenToolInfos(), true);
+        var cygwin = TemplateProcessor.processTemplate("cygwin", mavenToolInfos(), true);
+
+        assertThat(withoutBlankLines(cygwin)).isEqualTo(withoutBlankLines(shOnWindows));
+    }
+
+    /**
+     * The two templates differ only in how many blank lines their control tags leave
+     * behind, which says nothing about the script they produce.
+     */
+    private String withoutBlankLines(String script) {
+        return script.lines().filter(StringUtils::isNotBlank).reduce("", (a, b) -> a + b + "\n");
+    }
+
+    private Map<String, List<ToolInfo>> mavenToolInfos() {
+        var toolInfo = ImmutableToolInfo.builder()
+                .putEnvironmentVariables("MAVEN_HOME", new File("/tools/maven"))
+                .addPathElements(new File("/tools/maven/bin"))
+                .putUnhandledProjectResources("userSettingsFile", new File("/project/etc/m2/settings.xml"))
+                .build();
+
+        return Map.of("maven", List.of(toolInfo));
     }
 
     private String createTemplateInDirectory(String templateContent, File parentDirectory) throws Exception {


### PR DESCRIPTION
Two independent fixes to the shell templates. Both are about scripts that look
correct and silently do the wrong thing.

## The `sh` template did not work on Windows

It emitted plain paths:

```sh
export PATH="C:/tools/maven/bin:$PATH"
```

A POSIX shell on Windows is Cygwin or MSYS2, where `:` separates PATH entries.
So that entry splits into `C` and `/tools/maven/bin`, and the tool is not on
PATH. `sh` was effectively Windows-only-by-accident: usable for env vars,
broken for PATH.

The template now routes paths through `cygpath` when the target is Windows,
which is exactly what `cygwin.peb` already did.

The conversion stays a runtime `cygpath` call rather than a string transform in
Java on purpose: Cygwin and MSYS2 disagree on the result (`/cygdrive/c/x` vs
`/c/x`), so only the running shell knows the right answer.

## The Maven settings file was passed through an alias

```sh
alias mvn="mvn -s /project/etc/m2/settings.xml"
```

Aliases are expanded by interactive shells only. Every non-interactive caller
silently lost `-s` and used the default settings instead:

- CI scripts that source the generated script
- `sh -c` and any tool that shells out
- anything that sources the script and runs Maven in the same parse unit, since
  a shell resolves aliases at parse time, before the alias exists

Replaced with a shell function. `command mvn` prevents recursion.

```sh
mvn() {
    command mvn -s "/project/etc/m2/settings.xml" "$@"
}
```

The path is now quoted too, so a project directory containing a space no longer
breaks the invocation.

## How it was verified

`processTemplate` gained a package-private overload that takes the target OS, so
both branches are covered by tests on any machine rather than only on the host
platform.

- New unit tests for the function form, for untouched paths off Windows, for
  `cygpath` on Windows, and one asserting `cygwin` renders identically to `sh`
  on Windows.
- The existing integration test asserted `alias mvn`; updated to the function.
- Full `code/cli` suite green: 26 tests, including the integration test that
  renders through the real CLI against a real Maven install.
- The emitted function was run in `sh`, `bash` and `zsh`, including the
  same-parse-unit case that silently breaks an alias. No recursion, `-s` always
  applied.

## Follow-up, not in this PR

`cygwin.peb` now renders identically to `sh.peb` on Windows, so it is redundant.
Removing it is a breaking change for anyone passing `--output-template=cygwin`,
so it belongs in a future major version rather than here.

`pwsh.peb` is untouched. It already uses a function, and `Set-Alias` works in
non-interactive PowerShell.
